### PR TITLE
get products by categoryId

### DIFF
--- a/back/src/routes/categoriesRoutes.js
+++ b/back/src/routes/categoriesRoutes.js
@@ -1,5 +1,5 @@
 const { Router } = require("express")
-const { Category, Subcategory } = require("../db")
+const { Category, Subcategory, Product } = require("../db")
 const categoriesroutes = Router()
 const { Op } = require("sequelize")
 

--- a/back/src/routes/productRoutes.js
+++ b/back/src/routes/productRoutes.js
@@ -49,6 +49,22 @@ productRoutes.get("/", async (req, res) => {
     res.status(200).json({ data: lista })
 })
 
+//get products by categoryId
+productRoutes.get('/category/:idCategory', async (req, res) => {
+    let products
+    const categoryId = req.params.idCategory;           
+    const subCategory = await Subcategory.findAll({where: {categoryId: categoryId}})   
+    
+    subCategory.length ?
+    (
+        products = await Product.findAll({where: {subcategoryId: subCategory[0].id}}),
+        res.send(products)
+    )
+    
+    : res.send('No hay resultados.')
+  
+})
+
 
 
 module.exports = { productRoutes }


### PR DESCRIPTION
Esta ruta trae los productos de una categoría usando el id de categoria como parámetro.
http://localhost:3001/products/category/[ID_CATEGORY]

Ejemplo (Periféricos de PC): http://localhost:3001/products/category/27b859f1-0bfc-4ba1-8760-b7ae356244cc 

Los ids de categoría se pueden tomar de la ruta de Marcos: http://localhost:3001/categories

Ej. "id": "27b859f1-0bfc-4ba1-8760-b7ae356244cc
